### PR TITLE
build improvements and updates in tests/ref

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -18,11 +18,12 @@ include Make2
 
 ifneq ($(GNUCAP_CONF),)
     $(info asking $(GNUCAP_CONF))
-    CXX = $(shell $(GNUCAP_CONF) --cxx)
+    CXX             = $(shell $(GNUCAP_CONF) --cxx)   # c++
     GNUCAP_CPPFLAGS = $(shell $(GNUCAP_CONF) --cppflags) -DADD_VERSION
-	 GNUCAP_PLUGPATH = @plugpath@
+	GNUCAP_LDFLAGS  = $(shell $(GNUCAP_CONF) --ldflags)
     GNUCAP_CXXFLAGS = $(shell $(GNUCAP_CONF) --cxxflags)
-	 GNUCAP_LIBS = $(shell $(GNUCAP_CONF) --libs)
+	GNUCAP_LIBS     = $(shell $(GNUCAP_CONF) --libs)  # -lgnucap
+	 GNUCAP_PLUGPATH = @plugpath@
 	 GNUCAP_EXEC_PREFIX = @prefix@
 	 GNUCAP_PKGLIBDIR = @pkglibdir@
 	 GNUCSATOR_PKGLIBDIR=${GNUCAP_PKGLIBDIR}/qucs
@@ -37,7 +38,7 @@ ifneq ($(PREFIX),)
 	 GNUCSATOR_PKGLIBDIR = ${GNUCAP_LIBDIR}/gnucap/qucs
 endif
 
-GNUCAP_CXXFLAGS+= -fPIC -shared -Wall
+GNUCAP_CXXFLAGS+= -fPIC -std=c++11 -shared -Wall
 EXECUTABLES = \
   ${bin_PROGRAMS} ${dist_bin_SCRIPTS} ${contrib_bin_SCRIPTS}
 
@@ -90,7 +91,7 @@ ${QUCS_PLUGINS}: %.so: %.cc
 gncp: main.o config.h
 	$(CXX) $(CXXFLAGS) $(GNUCAP_CXXFLAGS) $(CPPFLAGS) $(GNUCAP_CPPFLAGS) -o $@ $< $(GNUCAP_LDFLAGS) $(LIBS)
 
-s_sparam.so: LDLIBS=-lgsl -lblas
+s_sparam.so: LDLIBS=-lgsl -lblas -lgslcblas
 
 d_eqn.so: CXXFLAGS+=-std=c++11
 cmd_wrapper.so: CXXFLAGS+=-std=c++11
@@ -134,7 +135,7 @@ define NOTICE
 endef
 
 Make2:
-	[ -e $@ ] || echo "# here you may override settings" > $@
+	[ -e $@ ] || echo "# here you may override settings\n#CXXFLAGS = -DDO_TRACE=1 -g3" > $@
 
 check: all
 	$(MAKE) -C tests check GNUCAP_PLUGPATH=${GNUCAP_PLUGPATH} \

--- a/configure
+++ b/configure
@@ -35,26 +35,26 @@ GNUCSATOR_PKGLIBDIR=${pkglibdir}/qucs
 PKGINCLUDEDIR=${prefix}/include/gnucap-qucs/
 
 fill_template() {
-t=$( tempfile )
-sed -e "s#@prefix@#$prefix#" \
-    -e "s#@exec_prefix@#$prefix#" \
-    -e "s#@libdir@#$prefix/lib#" \
-    -e "s#@NOTICE@#$NOTICE#" \
-    -e "s#@PKGINCLUDEDIR@#$PKGINCLUDEDIR#" \
-    -e "s#@includedir@#$\{prefix\}/include#" \
-    -e "s#@datarootdir@#$\{prefix\}/share/gnucap#" \
-    -e "s#@sysconfdir@#$sysconfdir#" \
-    -e "s#@pkglibdir@#$pkglibdir#" \
-    -e "s#@plugpath@#$plugpath#" \
-    -e "s#@CXXFLAGS@#$CCFLAGS#" \
-    -e "s#@LIBS@#-lgnucap#" \
-    -e "s#@STATUS@#$STATUS#" \
-    -e "s#@CXX@#$CXX#" < $1.in > $t
-if diff $1 $t >/dev/null; then
+  t=$( mktemp );#tempfile depricated -> mktemp
+  sed -e "s#@prefix@#$prefix#g" \
+    -e "s#@exec_prefix@#$prefix#g" \
+    -e "s#@libdir@#$prefix/lib#g" \
+    -e "s#@NOTICE@#$NOTICE#g" \
+    -e "s#@PKGINCLUDEDIR@#$PKGINCLUDEDIR#g" \
+    -e "s#@includedir@#$\{prefix\}/include#g" \
+    -e "s#@datarootdir@#$\{prefix\}/share/gnucap#g" \
+    -e "s#@sysconfdir@#$sysconfdir#g" \
+    -e "s#@pkglibdir@#$pkglibdir#g" \
+    -e "s#@plugpath@#$plugpath#g" \
+    -e "s#@CXXFLAGS@#$CCFLAGS#g" \
+    -e "s#@LIBS@#-lgnucap#g" \
+    -e "s#@STATUS@#$STATUS#g" \
+    -e "s#@CXX@#$CXX#g" < $1.in > $t
+  if diff $1 $t 2>&1 > /dev/null; then
 	rm $t;
-else
+  else
 	mv $t $1;
-fi
+  fi
 }
 
 fill_template config.h

--- a/tests/ref/AM_Mod.1.net.gc.out
+++ b/tests/ref/AM_Mod.1.net.gc.out
@@ -1,4 +1,4 @@
-default plugins: master 2017.10.03
+default plugins: develop 2019.12.20
 ;: already installed, replacing
 stashing as ;:0
 *: already installed, replacing

--- a/tests/ref/MUT.net.gc.out
+++ b/tests/ref/MUT.net.gc.out
@@ -1,4 +1,4 @@
-default plugins: master 2017.10.03
+default plugins: develop 2019.12.20
 ;: already installed, replacing
 stashing as ;:0
 *: already installed, replacing

--- a/tests/ref/Switch.0.net.gc.out
+++ b/tests/ref/Switch.0.net.gc.out
@@ -1,4 +1,4 @@
-default plugins: master 2017.10.03
+default plugins: develop 2019.12.20
 ;: already installed, replacing
 stashing as ;:0
 *: already installed, replacing

--- a/tests/ref/Vrect.1.net.gc.out
+++ b/tests/ref/Vrect.1.net.gc.out
@@ -1,4 +1,4 @@
-default plugins: master 2017.10.03
+default plugins: develop 2019.12.20
 ;: already installed, replacing
 stashing as ;:0
 *: already installed, replacing

--- a/tests/ref/Vrect.2.net.gc.out
+++ b/tests/ref/Vrect.2.net.gc.out
@@ -1,4 +1,4 @@
-default plugins: master 2017.10.03
+default plugins: develop 2019.12.20
 ;: already installed, replacing
 stashing as ;:0
 *: already installed, replacing

--- a/tests/ref/dio.net.gc.out
+++ b/tests/ref/dio.net.gc.out
@@ -1,4 +1,4 @@
-default plugins: master 2017.10.03
+default plugins: develop 2019.12.20
 ;: already installed, replacing
 stashing as ;:0
 *: already installed, replacing

--- a/tests/ref/lang_qucs.1.net.gc.out
+++ b/tests/ref/lang_qucs.1.net.gc.out
@@ -1,4 +1,4 @@
-default plugins: master 2017.10.03
+default plugins: develop 2019.12.20
 ;: already installed, replacing
 stashing as ;:0
 *: already installed, replacing

--- a/tests/ref/lang_qucs.2.net.gc.out
+++ b/tests/ref/lang_qucs.2.net.gc.out
@@ -1,4 +1,4 @@
-default plugins: master 2017.10.03
+default plugins: develop 2019.12.20
 ;: already installed, replacing
 stashing as ;:0
 *: already installed, replacing

--- a/tests/ref/lang_qucs.3.net.gc.out
+++ b/tests/ref/lang_qucs.3.net.gc.out
@@ -1,4 +1,4 @@
-default plugins: master 2017.10.03
+default plugins: develop 2019.12.20
 ;: already installed, replacing
 stashing as ;:0
 *: already installed, replacing

--- a/tests/ref/pac.net.gc.out
+++ b/tests/ref/pac.net.gc.out
@@ -1,4 +1,4 @@
-default plugins: master 2017.10.03
+default plugins: develop 2019.12.20
 ;: already installed, replacing
 stashing as ;:0
 *: already installed, replacing

--- a/tests/ref/rc.net.gc.out
+++ b/tests/ref/rc.net.gc.out
@@ -1,4 +1,4 @@
-default plugins: master 2017.10.03
+default plugins: develop 2019.12.20
 ;: already installed, replacing
 stashing as ;:0
 *: already installed, replacing

--- a/tests/ref/rr.net.gc.out
+++ b/tests/ref/rr.net.gc.out
@@ -1,4 +1,4 @@
-default plugins: master 2017.10.03
+default plugins: develop 2019.12.20
 ;: already installed, replacing
 stashing as ;:0
 *: already installed, replacing

--- a/tests/ref/sparam_e.net.gc.out
+++ b/tests/ref/sparam_e.net.gc.out
@@ -1,4 +1,4 @@
-default plugins: master 2017.10.03
+default plugins: develop 2019.12.20
 ;: already installed, replacing
 stashing as ;:0
 *: already installed, replacing

--- a/tests/ref/sub.1.net.gc.out
+++ b/tests/ref/sub.1.net.gc.out
@@ -1,4 +1,4 @@
-default plugins: master 2017.10.03
+default plugins: develop 2019.12.20
 ;: already installed, replacing
 stashing as ;:0
 *: already installed, replacing

--- a/tests/ref/sub.2.net.gc.out
+++ b/tests/ref/sub.2.net.gc.out
@@ -1,4 +1,4 @@
-default plugins: master 2017.10.03
+default plugins: develop 2019.12.20
 ;: already installed, replacing
 stashing as ;:0
 *: already installed, replacing


### PR DESCRIPTION
the build was not successfull on centos-7, changes made:
configure
  - mktemp instead tempfile (depricated) used
  - sed substitution global
  - suppressing confusing message from diff (file not found)

Makefile.in
  - one more -std=c++11 flag added (some files reported errors)
  - s_sparam.so: -lgslcblas added
    because of # ? /usr/local/lib/libgsl.so.25: undefined symbol: cblas_ctrmv

tests/ref
  - master -> develop